### PR TITLE
Fix pixiv proxy node creation

### DIFF
--- a/plugin/pixiv/proxy/node.go
+++ b/plugin/pixiv/proxy/node.go
@@ -66,9 +66,12 @@ func (m *Manager) DownloadingNode(url string) error {
 		return err
 	}
 	if len(nodes) > 0 {
-		if err := tx.Create(&nodes).Error; err != nil {
-			tx.Rollback()
-			return err
+		for i := range nodes {
+			node := nodes[i]
+			if err := tx.Create(&node).Error; err != nil {
+				tx.Rollback()
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- create pixiv proxy nodes one by one inside the transaction
- keep rollback behavior on failure while committing successfully created nodes

## Testing
- go test ./... *(fails: abineundo/main.go expects ref/custom/register.go which is missing in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934eca0acc883259eeb651863017402)