### PR TITLE
[plugin-pixiv-fix]duplicate single image send

### DIFF
--- a/plugin/pixiv/service.go
+++ b/plugin/pixiv/service.go
@@ -219,7 +219,6 @@ func (s *Service) SendIllusts(ctx *zero.Ctx, illusts []model.IllustCache) {
 				continue
 			}
 			msg = append(msg, message.Image("file:///"+filepath.ToSlash(res.ImgPaths[i])))
-			msg = append(msg, message.Image(res.ImgPaths[i]))
 		}
 
 		ctx.Send(msg)


### PR DESCRIPTION
### Motivation
- The Pixiv image send path was appending the same image twice, causing duplicate images to be sent in a single message.
- Each downloaded Pixiv image should be sent exactly once and using a `file:///` URI with normalized slashes.
- Remove the redundant append to prevent duplicated image sends.

### Description
- Removed the extra `msg = append(msg, message.Image(res.ImgPaths[i]))` in `plugin/pixiv/service.go` so each image is appended only once.
- Images are now sent using `message.Image("file:///"+filepath.ToSlash(res.ImgPaths[i]))` as before but without the duplicate raw-path append.
- Ran `gofmt` on the modified file to keep formatting consistent.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696454629fec832598215732d11430e6)