### PR TITLE
[plugin-matching-fix]使用正则表达式代替空格进行匹配

### DIFF
--- a/plugin/matching/main.go
+++ b/plugin/matching/main.go
@@ -136,7 +136,7 @@ func init() {
 			ctx.SendChain(message.Text("匹配时间为 ", m.ExpireAt/60, " 分钟"))
 		})
 
-	engine.OnRegex(`删除匹配软件 (.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
+	engine.OnRegex(`删除匹配软件\s+(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			uid := ctx.Event.UserID
 			softwareName := strings.ToLower(strings.TrimSpace(ctx.State["regex_matched"].([]string)[1]))
@@ -155,7 +155,7 @@ func init() {
 			ctx.SendChain(message.Text(m["message"]))
 		})
 
-	engine.OnRegex(`删除匹配黑名单 (.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
+	engine.OnRegex(`删除匹配黑名单\s+(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			uid := ctx.Event.UserID
 			targetText := strings.TrimSpace(ctx.State["regex_matched"].([]string)[1])
@@ -237,7 +237,7 @@ func init() {
 			ctx.SendChain(message.Text(msg.String()))
 		})
 
-	engine.OnRegex(`设置匹配黑名单 (.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
+	engine.OnRegex(`设置匹配黑名单\s+(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			uid := ctx.Event.UserID
 			targetText := strings.TrimSpace(ctx.State["regex_matched"].([]string)[1])
@@ -258,7 +258,7 @@ func init() {
 			ctx.SendChain(message.Text(fmt.Sprintf("%s[%d] 添加黑名单成功", ctx.CardOrNickName(uid), uid)))
 		})
 
-	engine.OnRegex(`设置匹配时间 (.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
+	engine.OnRegex(`设置匹配时间\s+(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			uid := ctx.Event.UserID
 			minutesText := strings.TrimSpace(ctx.State["regex_matched"].([]string)[1])
@@ -280,7 +280,7 @@ func init() {
 			ctx.SendChain(message.Text(fmt.Sprintf("%s[%d] 设置匹配时间成功", ctx.CardOrNickName(uid), uid)))
 		})
 
-	engine.OnRegex(`设置匹配软件 (.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
+	engine.OnRegex(`设置匹配软件\s+(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			uid := ctx.Event.UserID
 			software := strings.ToLower(strings.ReplaceAll(ctx.State["regex_matched"].([]string)[1], " ", ""))


### PR DESCRIPTION
### Motivation
- 修复匹配插件中若命令包含多个空格或其它空白字符导致正则不匹配的问题，通过在命令触发正则中使用 `\s+` 来兼容任意连贯空白。

### Description
- 在 `plugin/matching/main.go` 中将下列命令触发正则由字面单空格改为使用 `\s+`：`删除匹配软件 (.+)` -> `删除匹配软件\s+(.+)`、`删除匹配黑名单 (.+)` -> `删除匹配黑名单\s+(.+)`、`设置匹配黑名单 (.+)` -> `设置匹配黑名单\s+(.+)`、`设置匹配时间 (.+)` -> `设置匹配时间\s+(.+)`、`设置匹配软件 (.+)` -> `设置匹配软件\s+(.+)`。
- 未修改业务逻辑，只替换了触发正则以提高命令解析的鲁棒性。

### Testing
- 运行了 `go test ./plugin/matching/...`，测试命令执行完成且没有失败（包中无测试文件）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a919242c388325a6643b10f0c11f93)