### PR TITLE
[plugin-matching-fix]: 允许在命令正则表达式中使用可选的空白字符

### DIFF
--- a/plugin/matching/main.go
+++ b/plugin/matching/main.go
@@ -136,7 +136,7 @@ func init() {
 			ctx.SendChain(message.Text("匹配时间为 ", m.ExpireAt/60, " 分钟"))
 		})
 
-	engine.OnRegex(`删除匹配软件\s+(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
+	engine.OnRegex(`删除匹配软件\s*(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			uid := ctx.Event.UserID
 			softwareName := strings.ToLower(strings.TrimSpace(ctx.State["regex_matched"].([]string)[1]))
@@ -155,7 +155,7 @@ func init() {
 			ctx.SendChain(message.Text(m["message"]))
 		})
 
-	engine.OnRegex(`删除匹配黑名单\s+(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
+	engine.OnRegex(`删除匹配黑名单\s*(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			uid := ctx.Event.UserID
 			targetText := strings.TrimSpace(ctx.State["regex_matched"].([]string)[1])
@@ -237,7 +237,7 @@ func init() {
 			ctx.SendChain(message.Text(msg.String()))
 		})
 
-	engine.OnRegex(`设置匹配黑名单\s+(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
+	engine.OnRegex(`设置匹配黑名单\s*(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			uid := ctx.Event.UserID
 			targetText := strings.TrimSpace(ctx.State["regex_matched"].([]string)[1])
@@ -258,7 +258,7 @@ func init() {
 			ctx.SendChain(message.Text(fmt.Sprintf("%s[%d] 添加黑名单成功", ctx.CardOrNickName(uid), uid)))
 		})
 
-	engine.OnRegex(`设置匹配时间\s+(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
+	engine.OnRegex(`设置匹配时间\s*(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			uid := ctx.Event.UserID
 			minutesText := strings.TrimSpace(ctx.State["regex_matched"].([]string)[1])
@@ -280,7 +280,7 @@ func init() {
 			ctx.SendChain(message.Text(fmt.Sprintf("%s[%d] 设置匹配时间成功", ctx.CardOrNickName(uid), uid)))
 		})
 
-	engine.OnRegex(`设置匹配软件\s+(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
+	engine.OnRegex(`设置匹配软件\s*(.+)`, zero.OnlyPrivate, getDB).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			uid := ctx.Event.UserID
 			software := strings.ToLower(strings.ReplaceAll(ctx.State["regex_matched"].([]string)[1], " ", ""))


### PR DESCRIPTION
### Motivation
- Relax matching command regexes so user input is accepted even when the space after the command keyword is omitted or varies, improving command parsing robustness.

### Description
- Updated regex patterns in `plugin/matching/main.go` for the commands `删除匹配软件`, `删除匹配黑名单`, `设置匹配黑名单`, `设置匹配时间`, and `设置匹配软件` to use `\s*(.+)` instead of `\s+(.+)`.

### Testing
- Ran `go test ./plugin/matching` which completed (package contains no test files) and observed no change in package behavior.
- Ran `go test ./...` which fails in this repository due to an unrelated missing embed target (`abineundo/ref/custom/register.go`), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa2b9d839c832594fbeb380c0a5516)