### PR TITLE
[matching-fix]修复无法设置匹配时间

### DIFF
--- a/plugin/matching/handle.go
+++ b/plugin/matching/handle.go
@@ -400,6 +400,7 @@ func ensureProfile(userID int64, userName string, limitTime int64) error {
 
 func updateExpire(userID int64, seconds int64) error {
 	status, body, err := doJSON(http.MethodPatch, "/profile/"+strconv.FormatInt(userID, 10)+"/expire", map[string]any{
+		"expire_at":  seconds,
 		"limit_time": seconds,
 		"expire":     seconds,
 		"seconds":    seconds,


### PR DESCRIPTION
### Motivation
- Fix failing `设置匹配时间` where the backend returns `expire_at 必须大于 0` because the PATCH payload omitted the required `expire_at` field.

### Description
- Add `"expire_at": seconds` to the update payload in `updateExpire` within `plugin/matching/handle.go` so the server-side validation for `expire_at` is satisfied.

### Testing
- Ran `go test ./plugin/matching`, which completed successfully (package reports no test files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b280250e448325937c36d7a59f841b)