### PR TITLE
fix(pixiv): delay deletion of downloaded images to avoid ENOENT during async send

### DIFF
--- a/plugin/pixiv/service.go
+++ b/plugin/pixiv/service.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 var cacheFilling sync.Map
@@ -221,8 +222,9 @@ func (s *Service) SendIllusts(ctx *zero.Ctx, illusts []model.IllustCache) {
 		}
 
 		ctx.Send(msg)
-
-		cleanupPixivImages(res.ImgPaths)
+		// ZeroBot 发送是异步的，立即删除本地文件可能导致 OneBot 侧来不及读取。
+		// 这里延迟清理，避免出现 "ENOENT: no such file or directory"。
+		scheduleCleanupPixivImages(res.ImgPaths, 15*time.Second)
 
 		s.DB.Create(&model.SentImage{
 			GroupID: gid,
@@ -258,6 +260,17 @@ func cleanupPixivImages(paths []string) {
 		}
 		_ = os.Remove(imagePath)
 	}
+}
+
+func scheduleCleanupPixivImages(paths []string, delay time.Duration) {
+	if len(paths) == 0 {
+		return
+	}
+	local := append([]string(nil), paths...)
+	go func() {
+		time.Sleep(delay)
+		cleanupPixivImages(local)
+	}()
 }
 
 func (s *Service) BackgroundCacheFiller(keyword string, minCache int, r18Req bool, fetchCount int, gid int64) {


### PR DESCRIPTION
### Motivation
- The plugin wrote Pixiv images to `file.BOTPATH/data/pixiv` and deleted them immediately after calling `ctx.Send(msg)`, but `ctx.Send` is asynchronous and OneBot may try to open the file after it was removed, causing `ENOENT` errors.

### Description
- Modified `plugin/pixiv/service.go` to import `time` and schedule cleanup instead of removing files immediately after `ctx.Send(msg)`.
- Added `scheduleCleanupPixivImages(paths []string, delay time.Duration)` which spawns a goroutine to `cleanupPixivImages` after a delay, and preserved the existing `cleanupPixivImages` function.
- Kept immediate cleanup behavior for error paths (failed downloads still call `cleanupPixivImages` right away).
- The delay is currently set to `15 * time.Second` when scheduling cleanup after successful sends.

### Testing
- Ran `go test ./plugin/pixiv/...` which completed successfully (packages have no test files and no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db679d6c0483258e1bd4cfd121dc3a)