### PR TITLE
[pixiv-fix]使用临时文件和延迟清理来下载 Pixiv 图像

### DIFF
--- a/plugin/pixiv/service.go
+++ b/plugin/pixiv/service.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 var cacheFilling sync.Map
@@ -130,7 +131,14 @@ func (s *Service) SendIllusts(ctx *zero.Ctx, illusts []model.IllustCache) {
 							}
 							return
 						}
-						imagePath := buildPixivImagePath(ill1.PID, page+1, u)
+						imagePath, pathErr := createPixivTempImagePath(ill1.PID, page+1, u)
+						if pathErr != nil {
+							pageCh <- pageResult{
+								index: page,
+								err:   pathErr,
+							}
+							return
+						}
 						if writeErr := os.WriteFile(imagePath, img, 0644); writeErr != nil {
 							pageCh <- pageResult{
 								index: page,
@@ -166,7 +174,12 @@ func (s *Service) SendIllusts(ctx *zero.Ctx, illusts []model.IllustCache) {
 			} else {
 				img, err := s.API.Client.FetchPixivImage(ill1, ill1.OriginalURL)
 				if err == nil {
-					imagePath := buildPixivImagePath(ill1.PID, 0, ill1.OriginalURL)
+					imagePath, pathErr := createPixivTempImagePath(ill1.PID, 0, ill1.OriginalURL)
+					if pathErr != nil {
+						d.Err = pathErr
+						results <- d
+						return
+					}
 					if writeErr := os.WriteFile(imagePath, img, 0644); writeErr != nil {
 						d.Err = writeErr
 					} else {
@@ -221,14 +234,36 @@ func (s *Service) SendIllusts(ctx *zero.Ctx, illusts []model.IllustCache) {
 		}
 
 		ctx.Send(msg)
-
-		cleanupPixivImages(res.ImgPaths)
+		// ZeroBot 发送是异步的，立即删除本地文件可能导致 OneBot 侧来不及读取。
+		// 这里延迟清理，避免出现 "ENOENT: no such file or directory"。
+		scheduleCleanupPixivImages(res.ImgPaths, 15*time.Second)
 
 		s.DB.Create(&model.SentImage{
 			GroupID: gid,
 			PID:     res.Ill.PID,
 		})
 	}
+}
+
+func createPixivTempImagePath(pid int64, index int, rawURL string) (string, error) {
+	ext := pixivImageExt(rawURL)
+	baseDir := filepath.Join(file.BOTPATH, "data", "pixiv")
+	if err := os.MkdirAll(baseDir, 0o775); err != nil {
+		return "", err
+	}
+	pattern := fmt.Sprintf("%d-", pid)
+	if index > 0 {
+		pattern = fmt.Sprintf("%d-%d-", pid, index)
+	}
+	tmp, err := os.CreateTemp(baseDir, pattern+"*"+ext)
+	if err != nil {
+		return "", err
+	}
+	name := tmp.Name()
+	if err = tmp.Close(); err != nil {
+		return "", err
+	}
+	return name, nil
 }
 
 func buildPixivImagePath(pid int64, index int, rawURL string) string {
@@ -258,6 +293,17 @@ func cleanupPixivImages(paths []string) {
 		}
 		_ = os.Remove(imagePath)
 	}
+}
+
+func scheduleCleanupPixivImages(paths []string, delay time.Duration) {
+	if len(paths) == 0 {
+		return
+	}
+	local := append([]string(nil), paths...)
+	go func() {
+		time.Sleep(delay)
+		cleanupPixivImages(local)
+	}()
 }
 
 func (s *Service) BackgroundCacheFiller(keyword string, minCache int, r18Req bool, fetchCount int, gid int64) {


### PR DESCRIPTION
### Motivation
- Avoid race conditions where ZeroBot sends images asynchronously and immediate file deletion causes "ENOENT" errors by creating unique temporary files and delaying cleanup.
- Improve robustness of image download path handling by surfacing path creation errors instead of assuming static filenames.

### Description
- Added `createPixivTempImagePath` which creates a temp file under `file.BOTPATH/data/pixiv` using `os.CreateTemp` and returns the filename, and ensured the directory exists with `os.MkdirAll`.
- Replaced direct calls to `buildPixivImagePath` during downloads with `createPixivTempImagePath` and propagate any path creation errors to the caller.
- Added `scheduleCleanupPixivImages` to delete downloaded images after a delay and used it in `SendIllusts` with a 15 second delay to avoid deleting files before the OneBot side has read them, while keeping `cleanupPixivImages` for immediate removal when needed.
- Imported `time` and adjusted error handling where temp path creation can fail.

### Testing
- Ran `go test ./...` against the repository and unit tests completed successfully.
- Built the package (`go build`) to verify imports and types and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db679d6c0483258e1bd4cfd121dc3a)